### PR TITLE
feat: add GET /api/user/me endpoint for authenticated user profile

### DIFF
--- a/src/modules/user/controllers/FindCurrentUserController.ts
+++ b/src/modules/user/controllers/FindCurrentUserController.ts
@@ -1,0 +1,40 @@
+import { HttpRequest, HttpResponse } from "@src/shared/types/http";
+import { IUserTranslation } from "@modules/user/types/IUserTranslation";
+import { AbstractController } from "@src/shared/classes/AbstractController";
+import { FindUserByIdUseCase } from "../useCases/FindUserByIdUseCase";
+import { FindUserByIdResponseModel } from "../models/Response/FindUserByIdResponse.model";
+
+interface IFindCurrentUserController {
+  findUserByIdUseCase: FindUserByIdUseCase;
+}
+
+export class FindCurrentUserController extends AbstractController<IUserTranslation> {
+  private findUserByIdUseCase: FindUserByIdUseCase;
+
+  constructor(dependencies: IFindCurrentUserController) {
+    super();
+    this.findUserByIdUseCase = dependencies.findUserByIdUseCase;
+  }
+
+  async handle(
+    request: HttpRequest<undefined, undefined, undefined, IUserTranslation>,
+  ): Promise<HttpResponse<IUserTranslation, FindUserByIdResponseModel | null>> {
+    const userId = request.user?.id || "";
+    const user = await this.findUserByIdUseCase.execute(userId);
+    if (!user) {
+      return {
+        statusCode: 404,
+        message: "user.findUser.notFound",
+      };
+    }
+    return {
+      statusCode: 200,
+      data: {
+        id: user.id,
+        username: user.username,
+        email: user.email,
+      } as FindUserByIdResponseModel,
+      message: "user.findUser.found",
+    };
+  }
+}

--- a/src/modules/user/schemas/findCurrentUserSchema.ts
+++ b/src/modules/user/schemas/findCurrentUserSchema.ts
@@ -1,0 +1,54 @@
+import { z } from "@utils/index";
+
+const findCurrentUserSchema = {
+  schema: {
+    tags: ["Users"],
+    description: "Get the authenticated user's profile",
+    headers: z.object({
+      "accept-language": z.string().optional().default("en-US"),
+      authorization: z.string().describe("Bearer token"),
+    }),
+    response: {
+      200: z
+        .object({
+          statusCode: z.number().default(200),
+          message: z.string(),
+          data: z
+            .object({
+              id: z.string(),
+              username: z.string(),
+              email: z.string().email(),
+            })
+            .nullable(),
+        })
+        .describe("Current user data"),
+      401: z
+        .object({
+          statusCode: z.number().default(401),
+          message: z
+            .string()
+            .describe("Authorization required")
+            .default("Authorization required"),
+        })
+        .describe("Authorization required"),
+      404: z
+        .object({
+          statusCode: z.number().default(404),
+          message: z
+            .string()
+            .describe("User not found")
+            .default("User not found"),
+        })
+        .describe("User not found"),
+      500: z.object({
+        statusCode: z.number().default(500),
+        message: z
+          .string()
+          .describe("Internal server error")
+          .default("Internal server error"),
+      }),
+    },
+  },
+};
+
+export { findCurrentUserSchema };

--- a/src/modules/user/schemas/index.ts
+++ b/src/modules/user/schemas/index.ts
@@ -1,4 +1,5 @@
 export * from "./createUserSchema";
+export * from "./findCurrentUserSchema";
 export * from "./findUserSchema";
 export * from "./deleteUserSchema";
 export * from "./updateUserEmailSchema";

--- a/src/modules/user/user.routes.ts
+++ b/src/modules/user/user.routes.ts
@@ -2,12 +2,14 @@ import { FastifyTypedInstance } from "@src/shared/types/fastifyTypedInstance";
 import { CreateUserController } from "@modules/user/controllers/CreateUserController";
 import {
   createUserSchema,
+  findCurrentUserSchema,
   deleteUserSchema,
   findUserSchema,
   updateUserEmailSchema,
   listUsersSchema,
 } from "@modules/user/schemas";
 import { routeAdapter } from "@utils/routeAdapter";
+import { FindCurrentUserController } from "@modules/user/controllers/FindCurrentUserController";
 import { FindUserController } from "@modules/user/controllers/FindUserController";
 import { ListUsersController } from "@modules/user/controllers/ListUsersController";
 import { FindUserByEmailController } from "@modules/user/controllers/FindUserByEmailController";
@@ -63,6 +65,20 @@ const userRoutes = (app: FastifyTypedInstance) => {
     ),
   );
 
+  app.get(
+    "/me",
+    {
+      ...findCurrentUserSchema,
+      preHandler: app.authenticate,
+    },
+    routeAdapter(
+      new FindCurrentUserController({
+        findUserByIdUseCase: new FindUserByIdUseCase({
+          userRepository: new MongoUserRepository(),
+        }),
+      }),
+    ),
+  );
   app.get(
     "/:id",
     {

--- a/src/test/modules/user/unit/controllers/FindCurrentUserController.spec.ts
+++ b/src/test/modules/user/unit/controllers/FindCurrentUserController.spec.ts
@@ -1,0 +1,91 @@
+import { FindCurrentUserController } from "@modules/user/controllers/FindCurrentUserController";
+import { FindUserByIdUseCase } from "@modules/user/useCases/FindUserByIdUseCase";
+import { IUserTranslation } from "@modules/user/types/IUserTranslation";
+import enUs from "@src/modules/user/lang/en-us";
+import { HttpRequest } from "@src/shared/types/http";
+import { getTranslationMessageFromPath } from "@utils/getTranslationMessageFromPath";
+import CustomError from "@src/shared/classes/CustomError";
+
+describe("FindCurrentUserController", () => {
+  let controller: FindCurrentUserController;
+  let findUserByIdUseCase: jest.Mocked<FindUserByIdUseCase>;
+  const languagePack = enUs as IUserTranslation;
+
+  const createRequest = (
+    userId?: string,
+  ): HttpRequest<undefined, undefined, undefined, IUserTranslation> => ({
+    languagePack,
+    lang: "en-US",
+    headers: { authorization: "Bearer valid.token" },
+    user: userId ? { id: userId, email: "test@example.com" } : undefined,
+  });
+
+  beforeEach(() => {
+    findUserByIdUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<FindUserByIdUseCase>;
+
+    controller = new FindCurrentUserController({ findUserByIdUseCase });
+  });
+
+  it("Should return 200 with user data when user is found", async () => {
+    const mockUser = {
+      id: "user123",
+      username: "testuser",
+      email: "test@example.com",
+    };
+
+    findUserByIdUseCase.execute.mockResolvedValue(mockUser);
+
+    const request = createRequest("user123");
+    const { data, message, statusCode } = await controller.handle(request);
+
+    expect(findUserByIdUseCase.execute).toHaveBeenCalledWith("user123");
+    expect(findUserByIdUseCase.execute).toHaveBeenCalledTimes(1);
+    expect({
+      data,
+      message: getTranslationMessageFromPath(languagePack, message),
+      statusCode,
+    }).toEqual({
+      statusCode: 200,
+      message: getTranslationMessageFromPath<IUserTranslation>(
+        languagePack,
+        "user.findUser.found",
+      ),
+      data: mockUser,
+    });
+  });
+
+  it("Should return 404 when user is not found", async () => {
+    findUserByIdUseCase.execute.mockResolvedValue(null);
+
+    const request = createRequest("nonexistent-id");
+    const { message, statusCode } = await controller.handle(request);
+
+    expect(findUserByIdUseCase.execute).toHaveBeenCalledWith("nonexistent-id");
+    expect({
+      message: getTranslationMessageFromPath(languagePack, message),
+      statusCode,
+    }).toEqual({
+      statusCode: 404,
+      message: getTranslationMessageFromPath<IUserTranslation>(
+        languagePack,
+        "user.findUser.notFound",
+      ),
+    });
+  });
+
+  it("Should pass empty string when user id is not in token", async () => {
+    const request = createRequest();
+
+    findUserByIdUseCase.execute.mockRejectedValue(
+      new CustomError("shared.error.requiredFields", 400),
+    );
+
+    await expect(controller.handle(request)).rejects.toThrow(
+      new CustomError("shared.error.requiredFields", 400),
+    );
+
+    expect(findUserByIdUseCase.execute).toHaveBeenCalledWith("");
+  });
+});


### PR DESCRIPTION
This pull request introduces a new endpoint to retrieve the currently authenticated user's profile information. It adds a dedicated controller, schema validation, route registration, and comprehensive unit tests for this functionality.

**New "Current User" Endpoint Implementation:**

* Added `FindCurrentUserController` to handle requests for the authenticated user's profile, using the user's ID from the authentication token.
* Defined `findCurrentUserSchema` for request/response validation, including possible status codes and response structures.
* Registered the new `/me` route in `user.routes.ts`, secured with authentication middleware and using the new controller and schema. [[1]](diffhunk://#diff-5ff9b55ce728ac590a9418fa3424e10d8254b94ae9b0fcabcf91878763e698c8R5-R12) [[2]](diffhunk://#diff-5ff9b55ce728ac590a9418fa3424e10d8254b94ae9b0fcabcf91878763e698c8R68-R81)
* Exported the new schema from the schemas index for consistency and reusability.

**Testing:**

* Added unit tests for `FindCurrentUserController`, covering successful retrieval, user-not-found, and missing user ID scenarios.Allow the frontend to fetch the current user's profile using the JWT token. The endpoint reuses FindUserByIdUseCase, extracting the user id from the decoded token instead of URL params.